### PR TITLE
Make board display mode configurable in inspector

### DIFF
--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -2,52 +2,51 @@
 using System.Collections;
 
 public class BoardDisplay : MonoBehaviour {
-	// Because the current value of altitude is in the range of 0-100; 
-	float defaultScale = 0.01f;
+    // Because the current value of altitude is in the range of 0-100; 
+    float defaultScale = 0.01f;
 
-	MeshFilter meshFilter;
+    MeshFilter meshFilter;
 
-	void Start () {
-		meshFilter = GetComponent<MeshFilter> ();
-	}
+    void Start () {
+        meshFilter = GetComponent<MeshFilter> ();
+    }
 
-	public void DrawBoard (BoardNode[,] board) {
-		float[,] heightMap = GenerateHeightMap (board);
-		MeshData meshData = MeshGenerator.GenerateMeshData (heightMap);
-		Mesh mesh = meshData.GenerateMesh ();
-		meshFilter.sharedMesh = meshData.GenerateMesh ();
-	}
+    public void DrawBoard (BoardNode[,] board) {
+        float[,] heightMap = GenerateHeightMap (board);
+        MeshData meshData = MeshGenerator.GenerateMeshData (heightMap);
+        Mesh mesh = meshData.GenerateMesh ();
+        meshFilter.sharedMesh = meshData.GenerateMesh ();
+    }
 
-	float[,] GenerateHeightMap (BoardNode[,] board) {
-		int width = board.GetLength (0);
-		int height = board.GetLength (1);
-		float[,] heightMap = new float[width, height];
+    float[,] GenerateHeightMap (BoardNode[,] board) {
+        int width = board.GetLength (0);
+        int height = board.GetLength (1);
+        float[,] heightMap = new float[width, height];
 
-		for (int x = 0; x < width; x++) {
-			for (int y = 0; y < height; y++) {
-				BoardNode node = board[x,y];
-				heightMap[x, y] = node.altitude * defaultScale;;
-			}
-		}
-
-		return heightMap;
-	}
-
-	public void DrawBoardCubes (BoardNode[,] board) {
-		int width = board.GetLength (0);
-		int height = board.GetLength (1);
-
-		for (int x = 0; x < width; x++) {
-			for (int y = 0; y < height; y++) {
-				BoardNode node = board[x,y];
-				float scaledAltitude = node.altitude * defaultScale;
-				GameObject obj = GameObject.CreatePrimitive (PrimitiveType.Cube);
-				obj.transform.localScale = new Vector3 (1, scaledAltitude, 1);
-				obj.transform.localPosition = new Vector3 (x, scaledAltitude / 2f, y);
-				obj.transform.parent = transform;
-                obj.GetComponent<Renderer>().material.color = new Color((float)(node.temperature)/50f -.5f, 0, (float)(node.moisture) / 50f - .5f);
-
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                BoardNode node = board[x,y];
+                heightMap[x, y] = node.altitude * defaultScale;;
             }
-		}
-	}
+        }
+
+        return heightMap;
+    }
+
+    public void DrawBoardCubes (BoardNode[,] board) {
+        int width = board.GetLength (0);
+        int height = board.GetLength (1);
+
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                BoardNode node = board[x,y];
+                float scaledAltitude = node.altitude * defaultScale;
+                GameObject obj = GameObject.CreatePrimitive (PrimitiveType.Cube);
+                obj.transform.localScale = new Vector3 (1, scaledAltitude, 1);
+                obj.transform.localPosition = new Vector3 (x, scaledAltitude / 2f, y);
+                obj.transform.parent = transform;
+                obj.GetComponent<Renderer>().material.color = new Color((float)(node.temperature)/50f -.5f, 0, (float)(node.moisture) / 50f - .5f);
+            }
+        }
+    }
 }

--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -51,7 +51,7 @@ public class BoardDisplay : MonoBehaviour {
                 float scaledAltitude = heightMap[x, y];
                 GameObject obj = GameObject.CreatePrimitive (PrimitiveType.Cube);
                 obj.transform.localScale = new Vector3 (1, scaledAltitude, 1);
-                obj.transform.localPosition = new Vector3 (x - width/2, scaledAltitude / 2f, y - width/2);
+                obj.transform.localPosition = new Vector3 (x - width/2 + .5f, scaledAltitude / 2f, y - width/2 + .5f);
                 obj.transform.parent = transform;
                 obj.GetComponent<Renderer>().material.color = new Color((float)(node.temperature)/50f -.5f, 0, (float)(node.moisture) / 50f - .5f);
             }

--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -2,6 +2,9 @@
 using System.Collections;
 
 public class BoardDisplay : MonoBehaviour {
+    public enum DisplayMode {Mesh, Cube};
+    public DisplayMode displayMode;
+
     // Because the current value of altitude is in the range of 0-100; 
     float defaultScale = 0.01f;
 
@@ -13,9 +16,14 @@ public class BoardDisplay : MonoBehaviour {
 
     public void DrawBoard (BoardNode[,] board) {
         float[,] heightMap = GenerateHeightMap (board);
-        MeshData meshData = MeshGenerator.GenerateMeshData (heightMap);
-        Mesh mesh = meshData.GenerateMesh ();
-        meshFilter.sharedMesh = meshData.GenerateMesh ();
+
+        if (displayMode == DisplayMode.Mesh) {
+                MeshData meshData = MeshGenerator.GenerateMeshData (heightMap);
+                Mesh mesh = meshData.GenerateMesh ();
+                meshFilter.sharedMesh = meshData.GenerateMesh ();
+        } else if (displayMode == DisplayMode.Cube) {
+            DrawBoardCubes (board, heightMap);
+        }
     }
 
     float[,] GenerateHeightMap (BoardNode[,] board) {
@@ -33,17 +41,17 @@ public class BoardDisplay : MonoBehaviour {
         return heightMap;
     }
 
-    public void DrawBoardCubes (BoardNode[,] board) {
+    public void DrawBoardCubes (BoardNode[,] board, float[,] heightMap) {
         int width = board.GetLength (0);
         int height = board.GetLength (1);
 
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 BoardNode node = board[x,y];
-                float scaledAltitude = node.altitude * defaultScale;
+                float scaledAltitude = heightMap[x, y];
                 GameObject obj = GameObject.CreatePrimitive (PrimitiveType.Cube);
                 obj.transform.localScale = new Vector3 (1, scaledAltitude, 1);
-                obj.transform.localPosition = new Vector3 (x, scaledAltitude / 2f, y);
+                obj.transform.localPosition = new Vector3 (x - width/2, scaledAltitude / 2f, y - width/2);
                 obj.transform.parent = transform;
                 obj.GetComponent<Renderer>().material.color = new Color((float)(node.temperature)/50f -.5f, 0, (float)(node.moisture) / 50f - .5f);
             }

--- a/Assets/Scripts/MeshGenerator.cs
+++ b/Assets/Scripts/MeshGenerator.cs
@@ -9,7 +9,7 @@ public static class MeshGenerator {
  
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
-                Vector3 position = new Vector3 (x - width/2, heightMap[x, y], y - height/2);
+                Vector3 position = new Vector3 (x - width/2 + .5f, heightMap[x, y], y - height/2 + .5f);
                 meshData.AddVertex (position);
             }
         }


### PR DESCRIPTION
Adds a _Display Mode- dropdown to the **Board Display** component of the `GameBoard` object to choose which method to use for rendering.  Also fixed the alignment of both methods to be consistent and fixed up the whitespace issues (tabs) in BoardDisplay.cs.
