### PR TITLE
Add rotation controls for camera

### DIFF
--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -1,0 +1,12 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class CameraController : MonoBehaviour {
+    void Update () {
+		if (Input.GetKeyDown (KeyCode.LeftArrow)) {
+			transform.RotateAround (Vector3.zero, Vector3.up, -45f);
+		} else if (Input.GetKeyDown (KeyCode.RightArrow)) {
+			transform.RotateAround (Vector3.zero, Vector3.up, 45f);
+		}
+    }
+}

--- a/Assets/Scripts/CameraController.cs.meta
+++ b/Assets/Scripts/CameraController.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2a0ef595e6f8a4fb7bdd93d71fbd03dc
+timeCreated: 1472359902
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Left and right arrow keys will rotate the camera 45 degrees around the origin.

This script needs to be added as a component to the camera object in the scene to work.
