### PR TITLE
Add render mode that adds placeholder decorations

### DIFF
--- a/Assets/Scripts/Billboard.cs
+++ b/Assets/Scripts/Billboard.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class Billboard : MonoBehaviour {
+    public Transform camera;
+
+    void Update () {
+        transform.forward = camera.forward;
+    }
+}

--- a/Assets/Scripts/Billboard.cs.meta
+++ b/Assets/Scripts/Billboard.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bcd9a7718f2ec4dc7bfb02c255e92e24
+timeCreated: 1472361733
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds the 'Mesh With Billboards' render option, which adds a placeholder
quad with billboard behavior (always facing camera) to some nodes.

Billboard behavior is easier to see with #5 merged.  It generally works, though I've noticed a rare slight flicker.  If it's a persistent issue, we could either update the camera rotation and billboards at the same time, or adding a quick animation to the camera rotation would also probably fix it (and look nice).
