### PR TITLE
Update mesh colors

### DIFF
--- a/Assets/Scripts/MeshGenerator.cs
+++ b/Assets/Scripts/MeshGenerator.cs
@@ -7,10 +7,13 @@ public static class MeshGenerator {
         int height = heightMap.GetLength(1);
         MeshData meshData = new MeshData (width, height);
  
+        float uvOffsetX = .5f/width;
+        float uvOffsetY = .5f/height;
+
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 Vector3 position = new Vector3 (x - width/2 + .5f, heightMap[x, y], y - height/2 + .5f);
-                Vector2 uv = new Vector2 (x/(float)width, y/(float)height);
+                Vector2 uv = new Vector2 (x/(float)width - uvOffsetX, y/(float)height - uvOffsetY);
                 meshData.AddVertex (position, uv);
             }
         }


### PR DESCRIPTION
The logic that assigns moisture/temperatures to biomes for coloring is perhaps a little over complicated.  Right now I'm using 6 possible biomes for coloring and mixing in altitude to alter the brightness.  Looks like this:

<img width="831" alt="screen shot 2016-08-28 at 2 44 12 pm" src="https://cloud.githubusercontent.com/assets/2260961/18035922/ec3a5952-6d2d-11e6-8e4e-034fa3b8dcf4.png">

I also pushed the generated texture over so the pixels on the texture are centered on the vertices – before, the last row/column were actually not being displayed at all.  Going to need to add a border  around the play field so that the edge nodes can be full-sized squares but I'll save that for later.
