### PR TITLE
Add altitude biome categories

### DIFF
--- a/Assets/Scripts/BiomeGenerator.cs
+++ b/Assets/Scripts/BiomeGenerator.cs
@@ -21,7 +21,7 @@ public static class BiomeGenerator {
     public static Biome GetBiome (BoardNode node) {
         float scaledTemp = node.temperature / BOARD_NODE_SCALE;
         float scaledMoist = node.moisture / BOARD_NODE_SCALE;
-        
+        float scaledAlt = node.altitude / BOARD_NODE_SCALE;
         float moistureOffset = scaledMoist - scaledTemp/3;
         
         MoistureBiome moistureCategory;
@@ -46,26 +46,42 @@ public static class BiomeGenerator {
             temperatureCategory = TemperatureBiome.Tropical;
         }
 
-        return new Biome (moistureCategory, temperatureCategory);
+        AltitudeBiome altitudeCategory;
+
+        if (scaledAlt < .25f) {
+            altitudeCategory = AltitudeBiome.Valley;
+        } else if (scaledAlt < .5f) {
+            altitudeCategory = AltitudeBiome.Plain;
+        } else if (scaledAlt < .75f) {
+            altitudeCategory = AltitudeBiome.Hill;
+        } else {
+            altitudeCategory = AltitudeBiome.Mountain;
+        }
+
+        return new Biome (moistureCategory, temperatureCategory, altitudeCategory);
     }
 }
 
 public enum MoistureBiome {Dry, Moist, Wet, Water, Any};
 public enum TemperatureBiome {Cold, Temperate, Tropical, Any};
+public enum AltitudeBiome {Valley, Plain, Hill, Mountain, Any};
 
 public struct Biome {
     public readonly MoistureBiome moisture;
     public readonly TemperatureBiome temperature;
+    public readonly AltitudeBiome altitude;
 
-    public Biome (MoistureBiome moisture, TemperatureBiome temperature) {
+    public Biome (MoistureBiome moisture, TemperatureBiome temperature, AltitudeBiome altitude) {
         this.moisture = moisture;
         this.temperature = temperature;
+        this.altitude = altitude;
     }
 
     public static bool operator == (Biome a, Biome b) {
         return (
             (a.moisture == b.moisture || a.moisture == MoistureBiome.Any || b.moisture == MoistureBiome.Any) &&
-            (a.temperature == b.temperature || a.temperature == TemperatureBiome.Any || b.temperature == TemperatureBiome.Any)
+            (a.temperature == b.temperature || a.temperature == TemperatureBiome.Any || b.temperature == TemperatureBiome.Any) &&
+            (a.altitude == b.altitude || a.altitude == AltitudeBiome.Any || b.altitude == AltitudeBiome.Any)
         );
     }
 

--- a/Assets/Scripts/BiomeGenerator.cs
+++ b/Assets/Scripts/BiomeGenerator.cs
@@ -1,0 +1,89 @@
+using UnityEngine;
+using System.Collections;
+
+public static class BiomeGenerator {
+    const float BOARD_NODE_SCALE = 100;
+
+    public static Biome[,] GenerateBiomeData (BoardNode[,] board) {
+        int width = board.GetLength (0);
+        int height = board.GetLength (1);
+        Biome[,] biomeMap = new Biome[width,height];
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                BoardNode node = board[x, y];
+                biomeMap[x,y] = GetBiome (node);
+            }
+        }
+
+        return biomeMap;
+    }
+
+    public static Biome GetBiome (BoardNode node) {
+        float scaledTemp = node.temperature / BOARD_NODE_SCALE;
+        float scaledMoist = node.moisture / BOARD_NODE_SCALE;
+        
+        float moistureOffset = scaledMoist - scaledTemp/3;
+        
+        MoistureBiome moistureCategory;
+
+        if (moistureOffset < 0f) {
+            moistureCategory = MoistureBiome.Dry;
+        } else if (moistureOffset < .33f) {
+            moistureCategory = MoistureBiome.Moist;
+        } else if (moistureOffset < .66f) {
+            moistureCategory = MoistureBiome.Wet;
+        } else {
+            moistureCategory = MoistureBiome.Water;
+        }
+
+        TemperatureBiome temperatureCategory;
+
+        if (scaledTemp < .33f) {
+            temperatureCategory = TemperatureBiome.Cold;
+        } else if (scaledTemp < .66f) {
+            temperatureCategory = TemperatureBiome.Temperate;
+        } else {
+            temperatureCategory = TemperatureBiome.Tropical;
+        }
+
+        return new Biome (moistureCategory, temperatureCategory);
+    }
+}
+
+public enum MoistureBiome {Dry, Moist, Wet, Water, Any};
+public enum TemperatureBiome {Cold, Temperate, Tropical, Any};
+
+public struct Biome {
+    public readonly MoistureBiome moisture;
+    public readonly TemperatureBiome temperature;
+
+    public Biome (MoistureBiome moisture, TemperatureBiome temperature) {
+        this.moisture = moisture;
+        this.temperature = temperature;
+    }
+
+    public static bool operator == (Biome a, Biome b) {
+        return (
+            (a.moisture == b.moisture || a.moisture == MoistureBiome.Any || b.moisture == MoistureBiome.Any) &&
+            (a.temperature == b.temperature || a.temperature == TemperatureBiome.Any || b.temperature == TemperatureBiome.Any)
+        );
+    }
+
+    public static bool operator != (Biome a, Biome b) {
+        return !(a == b);
+    }
+
+    public override bool Equals (object other) {
+        try {
+            return (bool)(this == (Biome)other);
+        }
+        catch {
+            return false;
+        }
+    }
+
+    // Added to stop VSCode from complaining at me.  Shouldn't need to hash these anyways.
+    public override int GetHashCode () {
+        return 0;
+    }
+}

--- a/Assets/Scripts/BiomeGenerator.cs.meta
+++ b/Assets/Scripts/BiomeGenerator.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3719cc97a04b24aba8063dc87ebb3a61
+timeCreated: 1472413153
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -9,21 +9,39 @@ public class BoardDisplay : MonoBehaviour {
     public Transform camera;
 
     // These could be set up in the inspector UI, but for now I'll build them here.
-    Color tundraColor = new Color (.7f, .65f, .75f);
     Color desertColor = new Color (1, .85f, .5f);
-    Color rainForestColor = new Color (.25f, .5f, 0);
-    Color forestColor = new Color (0f, 1f, .25f);
     Color iceShelfColor = new Color (1, 1, 1);
-    Color oceanColor = new Color (0, .25f, 1);
+    Color tundraColor = new Color (.7f, .65f, .75f);
+    Color rainForestColor = new Color (.25f, .5f, 0);
+    Color deepWaterColor = new Color (0, .25f, 1);
+    Color shallowWaterColor = new Color (0, .5f, 1);
+    Color forestColor = new Color (0f, .75f, .25f);
+    Color mountainForestColor = new Color (.5f, .5f, .25f);
+    Color swampColor = new Color (.25f, .25f, .15f);
+    Color plainsColor = new Color (.5f, .75f, .25f);
+    Color borealColor = new Color (.25f, .5f, .5f);
+    Color mountainBorealColor = new Color (.65f, .75f, .75f);
+
     // To help spot holes in biome coverage.
     Color defaultColor = Color.magenta;
 
-    Biome desertBiome = new Biome (MoistureBiome.Dry, TemperatureBiome.Any);
-    Biome tundraBiome = new Biome (MoistureBiome.Moist, TemperatureBiome.Cold);
-    Biome forestBiome = new Biome (MoistureBiome.Moist, TemperatureBiome.Any);
-    Biome rainForestBiome = new Biome (MoistureBiome.Wet, TemperatureBiome.Tropical);
-    Biome oceanBiome = new Biome (MoistureBiome.Wet, TemperatureBiome.Any);
-    Biome iceShelfBiome = new Biome (MoistureBiome.Water, TemperatureBiome.Any);
+    // Any temperature, any altitude.
+    Biome desertBiome = new Biome (MoistureBiome.Dry, TemperatureBiome.Any, AltitudeBiome.Any);
+    Biome iceShelfBiome = new Biome (MoistureBiome.Water, TemperatureBiome.Any, AltitudeBiome.Any);
+
+    // Any altitude.
+    Biome tundraBiome = new Biome (MoistureBiome.Moist, TemperatureBiome.Cold, AltitudeBiome.Any);
+    Biome rainForestBiome = new Biome (MoistureBiome.Wet, TemperatureBiome.Tropical, AltitudeBiome.Any);
+ 
+    // Any temperature.
+    Biome deepWaterBiome = new Biome (MoistureBiome.Wet, TemperatureBiome.Any, AltitudeBiome.Valley);
+    Biome shallowWaterBiome = new Biome (MoistureBiome.Wet, TemperatureBiome.Any, AltitudeBiome.Plain);
+    Biome forestBiome = new Biome (MoistureBiome.Wet, TemperatureBiome.Any, AltitudeBiome.Hill);
+    Biome mountainForestBiome = new Biome (MoistureBiome.Wet, TemperatureBiome.Any, AltitudeBiome.Mountain);
+    Biome swampBiome = new Biome (MoistureBiome.Moist, TemperatureBiome.Any, AltitudeBiome.Valley);
+    Biome plainsBiome = new Biome (MoistureBiome.Moist, TemperatureBiome.Any, AltitudeBiome.Plain);
+    Biome borealBiome = new Biome (MoistureBiome.Moist, TemperatureBiome.Any, AltitudeBiome.Hill);
+    Biome mountainBorealBiome = new Biome (MoistureBiome.Moist, TemperatureBiome.Any, AltitudeBiome.Mountain);
 
     // TODO - Can simplify the logic that that selects the biome by creating a dictionary
     // that ties biomes to colors, but I don't think that works with the "Any" types.  Will
@@ -120,24 +138,35 @@ public class BoardDisplay : MonoBehaviour {
                 Color color;
                 if (biome == desertBiome) {
                     color = desertColor;
-                } else if (biome == tundraBiome) {
-                    color = tundraColor;
-                } else if (biome == forestBiome) {
-                    color = forestColor;
-                } else if (biome == rainForestBiome) {
-                    color = rainForestColor;
-                } else if (biome == oceanBiome) {
-                    color = oceanColor;
                 } else if (biome == iceShelfBiome) {
                     color = iceShelfColor;
+                } else if (biome == tundraBiome) {
+                    color = tundraColor;
+                } else if (biome == rainForestBiome) {
+                    color = rainForestColor;
+                } else if (biome == deepWaterBiome) {
+                    color = deepWaterColor;
+                } else if (biome == shallowWaterBiome) {
+                    color = shallowWaterColor;
+                } else if (biome == forestBiome) {
+                    color = forestColor;
+                } else if (biome == mountainForestBiome) {
+                    color = mountainForestColor;
+                } else if (biome == swampBiome) {
+                    color = swampColor;
+                } else if (biome == plainsBiome) {
+                    color = plainsColor;
+                } else if (biome == borealBiome) {
+                    color = borealColor;
+                } else if (biome == mountainBorealBiome) {
+                    color = mountainBorealColor;
                 } else {
+                    // Debug.Log ("moist: " + biome.moisture + " temp: " + biome.temperature + " alt: " + biome.altitude);
                     color = defaultColor;
                 }
 
-                float scaledAltitude = node.altitude / MAX_ALTITUDE;
-                Color color2 = Color.Lerp (Color.black, Color.white, scaledAltitude);
-
-                colorMap[x + width*y] = Color.Lerp (color, color2, .5f);
+                Color color2 = Color.Lerp (Color.black, Color.white, node.altitude / MAX_ALTITUDE);
+                colorMap[x + width*y] = Color.Lerp (color, color2, .33f);
             }
         }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -3,7 +3,6 @@ using System.Collections;
 
 public class GameManager : MonoBehaviour
 {
-
     public int width;
     public int height;
     public enum WetDry { wet, dry };
@@ -12,6 +11,7 @@ public class GameManager : MonoBehaviour
     public ColdHot makeColdHot;
     public enum HighLow { high, low };
     public HighLow makeHighLow;
+    public bool upateEachTick = true;
 
     private float atmosphericDiffusion = .01f; //The amount adjacent blocks "blur" their props per tick.  Magnified by 4, since 4 cardinal neighbors influence you.
 
@@ -29,6 +29,10 @@ public class GameManager : MonoBehaviour
    
     void FixedUpdate()
     {
+        if (!upateEachTick) {
+            return;
+        }
+
         int width = board.GetLength(0);
         int height = board.GetLength(1);
 


### PR DESCRIPTION
<img width="779" alt="screen shot 2016-08-28 at 5 40 39 pm" src="https://cloud.githubusercontent.com/assets/2260961/18036959/a53f2406-6d46-11e6-8adc-fba2abdfece4.png">

Assignment to specific biomes based on BoardNode data is moved out into the `BiomeGenerator` class.  I added a few more placeholder colors for biomes, and I also added an option to disable the re-rendering each frame since it was bogging down the log when debugging for me.
