### PR TITLE
Add hd texture option and fix texture offset

### DIFF
--- a/Assets/Scripts/MeshGenerator.cs
+++ b/Assets/Scripts/MeshGenerator.cs
@@ -13,7 +13,7 @@ public static class MeshGenerator {
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 Vector3 position = new Vector3 (x - width/2 + .5f, heightMap[x, y], y - height/2 + .5f);
-                Vector2 uv = new Vector2 (x/(float)width - uvOffsetX, y/(float)height - uvOffsetY);
+                Vector2 uv = new Vector2 (x/(float)width + uvOffsetX, y/(float)height + uvOffsetY);
                 meshData.AddVertex (position, uv);
             }
         }


### PR DESCRIPTION
The texture was nudged in the wrong direction, so every tile was showing the wrong pixel.  At least, I'm pretty sure that's what was happening.  I checked it out at a large map size and the alignment of the biome regions seemed to make more sense as well.

Additionally, I added a 2x texture option.  When this is enabled (via a checkbox in the inspector), each tile will get a 2x2 pixel texture centered on its vetex.  Pixels adjacent to higher tiles will blend them into their color, otherwise the output is the same.

<img width="715" alt="screen shot 2016-08-28 at 9 32 39 pm" src="https://cloud.githubusercontent.com/assets/2260961/18038547/92aae052-6d67-11e6-9800-33bea9c6d56d.png">
