### PR TITLE
Destroy doodads when redrawing

### DIFF
--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -65,6 +65,8 @@ public class BoardDisplay : MonoBehaviour {
 
     public Transform waterCube;
 
+    List<GameObject> doodads = new List<GameObject> ();
+
     void Start () {
         meshFilter = GetComponent<MeshFilter> ();
         meshRenderer = GetComponent<MeshRenderer> ();
@@ -77,6 +79,11 @@ public class BoardDisplay : MonoBehaviour {
     }
 
     public void DrawBoard (BoardNode[,] board) {
+        foreach (GameObject obj in doodads) {
+            Destroy (obj);
+        }
+        doodads.Clear ();
+
         int width = board.GetLength (0);
         int height = board.GetLength (1);
         float[,] heightMap = GenerateHeightMap (board);
@@ -315,6 +322,7 @@ public class BoardDisplay : MonoBehaviour {
                 obj.transform.localPosition = new Vector3 (x - width/2 + .5f, scaledAltitude / 2f, y - width/2 + .5f);
                 obj.transform.parent = transform;
                 obj.GetComponent<Renderer>().material.color = colorMap[x + width*y];
+                doodads.Add (obj);
             }
         }
     }
@@ -340,6 +348,7 @@ public class BoardDisplay : MonoBehaviour {
                     obj.transform.localPosition = new Vector3 (x - width/2 + .5f, heightMap[x,y] + .25f, y - width/2 + .5f);
                     obj.transform.parent = transform;
                     obj.GetComponent<Renderer>().material.color = Color.Lerp (Color.black, Color.red, .66f);
+                    doodads.Add (obj);
                 }
             }
         }
@@ -382,6 +391,7 @@ public class BoardDisplay : MonoBehaviour {
 
                     obj.transform.localPosition = new Vector3 (x - width/2 + .5f, heightMap[x,y] + heightOffset, y - width/2 + .5f);
                     obj.transform.parent = transform;
+                    doodads.Add (obj);
                 }
             }
         }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -17,12 +17,14 @@ public class GameManager : MonoBehaviour
 
     BoardNode[,] board;
 
+    BoardDisplay display;
+
     void Start()
     {
         board = BoardGenerator.GenerateBoard(width, height);
-        BoardDisplay display = FindObjectOfType<BoardDisplay>();
-        if (display != null)
-        {
+
+        display = FindObjectOfType<BoardDisplay>();
+        if (display != null) {
             display.DrawBoard(board);
         }
     }
@@ -84,7 +86,10 @@ public class GameManager : MonoBehaviour
             
         }
         board = board_after;
-        FindObjectOfType<BoardDisplay>().DrawBoard(board);
+
+        if (display != null) {
+            display.DrawBoard(board);
+        }
     }
     
     void Update()
@@ -144,9 +149,9 @@ public class GameManager : MonoBehaviour
                     board[row, col].moisture -= 10;
                 }
 
-                BoardDisplay display = FindObjectOfType<BoardDisplay>();
-                display.DrawBoard(board);
-
+                if (display != null) {
+                    display.DrawBoard(board);
+                }
             }
         }    
     }


### PR DESCRIPTION
All of the `GameObject`s generated during rendering were getting re-created on each render but never removed, so huge amounts of objects could build up.  The `BoardDisplay` object now keeps a list of `GameObject`s it generates during rendering and destroys them before each render.

I also added a cached reference to the `BoardDisplay` object used to draw the board inside the `GameManager`, since I think `FindObjectOfType` has to search the entire scene each time.  Probably only a minor improvement.
