### PR TITLE
Add auto redraw to inspector

### DIFF
--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1ff5050f4401045539f31a464dcb4d39
+folderAsset: yes
+timeCreated: 1472531230
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/BoardDisplayEditor.cs
+++ b/Assets/Editor/BoardDisplayEditor.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using System.Collections;
+using UnityEditor;
+
+[CustomEditor (typeof (BoardDisplay))]
+public class BoardDisplayEditor : Editor {
+	public override void OnInspectorGUI() {
+		BoardDisplay display = (BoardDisplay)target;
+
+		if (DrawDefaultInspector()) {
+			if (display.autoUpdate) {
+				display.DrawBoard ();
+			}
+		}
+
+		if (GUILayout.Button ("Refresh")) {
+			display.DrawBoard ();
+		}
+	}
+}

--- a/Assets/Editor/BoardDisplayEditor.cs.meta
+++ b/Assets/Editor/BoardDisplayEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f38ef8c7d8c14488aba61d4588b793dc
+timeCreated: 1472531230
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -11,18 +11,18 @@ public class BoardDisplay : MonoBehaviour {
     public bool hdColorMap;
 
     // These could be set up in the inspector UI, but for now I'll build them here.
-    Color desertColor = new Color (1, .85f, .5f);
-    Color iceShelfColor = new Color (1, 1, 1);
-    Color tundraColor = new Color (.7f, .65f, .75f);
-    Color rainForestColor = new Color (.25f, .5f, 0);
-    Color deepWaterColor = new Color (0, .25f, 1);
-    Color shallowWaterColor = new Color (0, .5f, 1);
-    Color forestColor = new Color (0f, .75f, .25f);
-    Color mountainForestColor = new Color (.5f, .5f, .25f);
-    Color swampColor = new Color (.25f, .25f, .15f);
-    Color plainsColor = new Color (.5f, .75f, .25f);
-    Color borealColor = new Color (.25f, .5f, .5f);
-    Color mountainBorealColor = new Color (.65f, .75f, .75f);
+    public Color desertColor = new Color (1, .85f, .5f);
+    public Color iceShelfColor = new Color (1, 1, 1);
+    public Color tundraColor = new Color (.7f, .65f, .75f);
+    public Color rainForestColor = new Color (.25f, .5f, 0);
+    public Color deepWaterColor = new Color (0, .25f, 1);
+    public Color shallowWaterColor = new Color (0, .5f, 1);
+    public Color forestColor = new Color (0f, .75f, .25f);
+    public Color mountainForestColor = new Color (.5f, .5f, .25f);
+    public Color swampColor = new Color (.25f, .25f, .15f);
+    public Color plainsColor = new Color (.5f, .75f, .25f);
+    public Color borealColor = new Color (.25f, .5f, .5f);
+    public Color mountainBorealColor = new Color (.65f, .75f, .75f);
 
     // To help spot holes in biome coverage.
     Color defaultColor = Color.magenta;

--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -65,6 +65,10 @@ public class BoardDisplay : MonoBehaviour {
 
     public Transform waterCube;
 
+    // These enable automatic redraw when changing values in the editor;
+    public bool autoUpdate = true;
+    BoardNode[,] lastBoard;
+
     List<GameObject> doodads = new List<GameObject> ();
 
     void Start () {
@@ -78,7 +82,15 @@ public class BoardDisplay : MonoBehaviour {
         altitudeBiomeIndices.Add(AltitudeBiome.Mountain, 3);
     }
 
+    public void DrawBoard () {
+        if (lastBoard != null) {
+            DrawBoard (lastBoard);
+        }
+    }
+
     public void DrawBoard (BoardNode[,] board) {
+        lastBoard = board;
+
         foreach (GameObject obj in doodads) {
             Destroy (obj);
         }


### PR DESCRIPTION
Adds an option (on by default) to have the board be re-rendered any time anything changes in the inspector panel.  As part of this, `BoardDisplay` now stores a copy of the last board state it rendered, and that can be redrawn by calling `BoardDisplay.DrawBoard` with no arguments.

I'm also exposing the biome colors publicly so you can play with the colors and see the texture update immediately.
