### PR TITLE
Add option to create board from template

### DIFF
--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -121,10 +121,11 @@ public class BoardDisplay : MonoBehaviour {
         }
 
         if (waterCube != null) {
-            // Adjust the water level;
+            // Adjust the water level.  The offset is to prevent z-fighting when water and altitude are both 0.
+            float waterLevelOffset = .1f;
             float waterLevel = GetWaterLevel (board, heightMap);
             waterCube.transform.localScale = new Vector3 (width - 1, waterLevel, height - 1);
-            waterCube.transform.localPosition = new Vector3 (0, waterLevel/2, 0); 
+            waterCube.transform.localPosition = new Vector3 (0, waterLevel/2 - waterLevelOffset, 0);
         }
     }
 

--- a/Assets/Scripts/BoardGenerator.cs
+++ b/Assets/Scripts/BoardGenerator.cs
@@ -30,8 +30,21 @@ public static class BoardGenerator {
 
 		return board;
 	}
+
+    public static BoardNode[,] CreateUniformBoard (int width, int height, BoardNode node) {
+        BoardNode[,] board = new BoardNode[width, height];
+
+		for (int x = 0; x < width; x++) {
+			for (int y = 0; y < height; y++) {
+                board[x,y] = node;
+            }
+        }
+
+        return board;
+    }
 }
 
+[System.Serializable]
 public struct BoardNode {
 	public int altitude;
 	public int moisture;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -10,6 +10,8 @@ public class GameManager : MonoBehaviour
     public bool upateEachTick = true;
     public int brushMagnitude = 10;
     private float atmosphericDiffusion = .01f; //The amount adjacent blocks "blur" their props per tick.  Magnified by 4, since 4 cardinal neighbors influence you.
+    public bool useTemplateNode = false;
+    public BoardNode templateNode;
 
     BoardNode[,] board;
 
@@ -17,7 +19,11 @@ public class GameManager : MonoBehaviour
 
     void Start()
     {
-        board = BoardGenerator.GenerateBoard(width, height);
+        if (useTemplateNode) {
+            board = BoardGenerator.CreateUniformBoard (width, height, templateNode);
+        } else {
+            board = BoardGenerator.GenerateBoard(width, height);
+        }
 
         display = FindObjectOfType<BoardDisplay>();
         if (display != null) {


### PR DESCRIPTION
Adds a turndown to the `GameManager` component for specifying a node to use as a template, and a checkbox to enable it.  When enabled, all nodes on the board will be copied from the template rather than being randomly generated.

The extra commit pushes the water level down a hair because there was z-fighting when the board was perfectly flat at the lowest altitude and moisture settings.
