### PR TITLE
Diff board states and redraw necessary components

### DIFF
--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -137,7 +137,7 @@ public class BoardDisplay : MonoBehaviour {
 
         lastBoard = board;
         if (lastBoardCopy == null) {
-            lastBoard = new BoardNode[width, height];
+            lastBoardCopy = new BoardNode[width, height];
         }
         if (drawPartialUpdates) {
             Array.Copy (board, lastBoardCopy, width * height);

--- a/Assets/Scripts/BoardDisplay.cs
+++ b/Assets/Scripts/BoardDisplay.cs
@@ -310,9 +310,6 @@ public class BoardDisplay : MonoBehaviour {
     }
 
     public void DrawBoardMesh (float[,] heightMap, Color[] colorMap) {
-        int width = heightMap.GetLength (0);
-        int height = heightMap.GetLength (1);
-
         MeshData meshData = MeshGenerator.GenerateMeshData (heightMap);
         meshFilter.sharedMesh = meshData.GenerateMesh ();
 

--- a/Assets/Scripts/BoardGenerator.cs
+++ b/Assets/Scripts/BoardGenerator.cs
@@ -56,4 +56,31 @@ public struct BoardNode {
 		this.temperature = temperature;
         this.wind = wind;
 	}
+
+    public static bool operator == (BoardNode a, BoardNode b) {
+        // Ignores wind for the time being.
+        return (
+            a.altitude == b.altitude &&
+            a.moisture == b.moisture &&
+            a.temperature == b.temperature
+        );
+    }
+
+    public static bool operator != (BoardNode a, BoardNode b) {
+        return !(a == b);
+    }
+
+    public override bool Equals (object other) {
+        try {
+            return (bool)(this == (BoardNode)other);
+        }
+        catch {
+            return false;
+        }
+    }
+
+    // Added to stop VSCode from complaining at me.  Shouldn't need to hash these anyways.
+    public override int GetHashCode () {
+        return 0;
+    }
 }


### PR DESCRIPTION
A first stab at improving rendering.  This diffs the new board state against the last one to find what has changed, and will only redraw the necessary components (e.g. the mesh is only redrawn if any of the heights have changed). TBH I have no idea how much this improves anything (if at all), so I made it optional, I need to look into how to profile properly in unity.

A slight improvement could be to have an optional form of the `DrawBoard` function that accepts a `BoardDiffState`, so the caller can just tell the renderer what has changed.  Another improvement would be to redraw the individual components smartly (e.g. only recalculate the vertices/triangles that should change when the mesh needs to be redrawn), but that's probably more work than I want to do right now.
